### PR TITLE
Fix bug when parsing named character references that contain numbers

### DIFF
--- a/Sources/HTMLEntities/Utilities.swift
+++ b/Sources/HTMLEntities/Utilities.swift
@@ -27,9 +27,9 @@ func invert<K, V: Hashable>(_ dict: [K: V]) -> [V: K] {
 }
 
 extension UInt32 {
-    var isAlpha: Bool {
-        // ASCII values of [A-Z] and [a-z]
-        return 65...90 ~= self || 97...122 ~= self
+    var isAlphaNumeric: Bool {
+        // ASCII values of [0-9], [A-Z0, [and [a-z]
+        return self.isNumeral || 65...90 ~= self || 97...122 ~= self
     }
 
     var isAmpersand: Bool {
@@ -86,7 +86,7 @@ extension UInt32 {
         case .Hex:
             return self.isHexNumeral
         case .Named:
-            return self.isAlpha
+            return self.isAlphaNumeric
         default:
             return false
         }

--- a/Tests/HTMLEntitiesTests/HTMLEntitiesTest.swift
+++ b/Tests/HTMLEntitiesTests/HTMLEntitiesTest.swift
@@ -33,6 +33,18 @@ let str3Unescaped = "Jako efektivnější se nám jeví pořádání tzv. Road S
 let str3Escaped = "Jako efektivn&#x11B;j&#x161;&#xED; se n&#xE1;m jev&#xED; po&#x159;&#xE1;d&#xE1;n&#xED; tzv. Road Show prost&#x159;ednictv&#xED;m na&#x161;ich autorizovan&#xFD;ch dealer&#x16F; v &#x10C;ech&#xE1;ch a na Morav&#x11B;, kter&#xE9; prob&#x11B;hnou v pr&#x16F;b&#x11B;hu z&#xE1;&#x159;&#xED; a &#x159;&#xED;jna."
 
 class HTMLEntitiesTests: XCTestCase {
+    func testNamedCharacterReferences() {
+        XCTAssertEqual(html4NamedCharactersDecodeMap.count, html4NamedCharactersEncodeMap.count)
+
+        for (reference, unicode) in html4NamedCharactersDecodeMap {
+            let unescaped = String(UnicodeScalar(unicode)!)
+            let escaped = reference
+
+            XCTAssertEqual(unescaped.htmlEscape(), escaped)
+            XCTAssertEqual(escaped.htmlUnescape(), unescaped)
+        }
+    }
+
     func testEncode() {
         XCTAssertEqual(str1Unescaped.htmlEscape(), str1Escaped)
         XCTAssertEqual(str2Unescaped.htmlEscape(), str2Escaped)
@@ -105,6 +117,7 @@ class HTMLEntitiesTests: XCTestCase {
 
     static var allTests : [(String, (HTMLEntitiesTests) -> () throws -> Void)] {
         return [
+            ("testNamedCharacterReferences", testNamedCharacterReferences),
             ("testEncode", testEncode),
             ("testDecode", testDecode),
             ("testInvertibility", testInvertibility),


### PR DESCRIPTION
Also fix bug on Linux when unescaping strings with only empty-string-equivalent character escapes.
