### PR TITLE
Prevent the "dylib not safe for use in extensions" warning

### DIFF
--- a/HTMLEntities-Carthage.xcodeproj/project.pbxproj
+++ b/HTMLEntities-Carthage.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		OBJ_23 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -234,6 +235,7 @@
 		OBJ_24 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## Abstract

Prevent the X-Code warning "linking against a dylib which is not safe for use in application extensions" while using this Framework for an App Extension Target.

## Description

This PR sets the X-Code "Allow app extension API only" checkbox so this library can also be used for App Extensions (e.g. Today Extension etc.) without warnings.

Because this Framework does not use any [APIs which are not available for Extensions](https://developer.apple.com/library/content/documentation/General/Conceptual/ExtensibilityPG/ExtensionOverview.html#//apple_ref/doc/uid/TP40014214-CH2-SW6), this change has no implications or side effects.

## Checklist:

- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.