### PR TITLE
Set Carthage Swift version to 4.2 (Swift 4 + 5 compatibility)

### DIFF
--- a/HTMLEntities-Carthage.xcodeproj/project.pbxproj
+++ b/HTMLEntities-Carthage.xcodeproj/project.pbxproj
@@ -287,7 +287,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				USE_HEADERMAP = NO;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
@@ -347,7 +347,7 @@
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				USE_HEADERMAP = NO;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update the Swift version to 4.2 in the Carthage support Xcode project

## Motivation and Context

The current Xcode project specifies Swift 3. This will be incompatible with Swift 5 being released shortly in Xcode 10.2.

By specifying Swift 4.2, swift-html-entities will be compatible with both Swift 4.2 and Swift 5.

## How Has This Been Tested?

Carthage build using Xcode 10.1 and Xcode 10.2 beta 3 as the set toolchains.

*After reading below* I will get a CLA form signed shortly!

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.