### PR TITLE
Remove redundant public modifiers

### DIFF
--- a/Sources/HTMLEntities/String+HTMLEntities.swift
+++ b/Sources/HTMLEntities/String+HTMLEntities.swift
@@ -18,7 +18,7 @@
 /// HTML escaped equivalents and vice versa.
 public extension String {
     /// Global HTML escape options
-    public struct HTMLEscapeOptions {
+    struct HTMLEscapeOptions {
         /// Specifies if all ASCII characters should be skipped when escaping text
         public static var allowUnsafeSymbols = false
 
@@ -62,7 +62,7 @@ public extension String {
     /// some are safe characters. *Optional*
     /// - Parameter useNamedReferences: Specifies if named character references
     /// should be used whenever possible. *Optional*
-    public func htmlEscape(allowUnsafeSymbols: Bool = HTMLEscapeOptions.allowUnsafeSymbols,
+    func htmlEscape(allowUnsafeSymbols: Bool = HTMLEscapeOptions.allowUnsafeSymbols,
                            decimal: Bool = HTMLEscapeOptions.decimal,
                            encodeEverything: Bool = HTMLEscapeOptions.encodeEverything,
                            useNamedReferences: Bool = HTMLEscapeOptions.useNamedReferences)
@@ -127,7 +127,7 @@ public extension String {
     ///
     /// - Parameter strict: Specifies if escapes MUST always end with `;`.
     /// - Throws: (Only if `strict == true`) The first `ParseError` encountered during parsing.
-    public func htmlUnescape(strict: Bool) throws -> String {
+    func htmlUnescape(strict: Bool) throws -> String {
         // result buffer
         var str = ""
 
@@ -371,7 +371,7 @@ public extension String {
     /// `"<script>alert(\"abc\")</script>"`
     ///
     /// Equivalent to `htmlUnescape(strict: false)`, but does NOT throw parse error.
-    public func htmlUnescape() -> String {
+    func htmlUnescape() -> String {
         // non-strict mode should never throw error
         return try! self.htmlUnescape(strict: false)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes 4 warnings relating to redundant public modifiers.

## Motivation and Context

<Description>

0 tolerance for warnings can help prevent [Broken Windows Syndrome](https://en.wikipedia.org/wiki/Broken_windows_theory)

## How Has This Been Tested?

I entirely relied on the compiler for this one.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
