### PR TITLE
Minimum Swift version is now 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci-ubuntu16.04:5.1.5
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci-ubuntu16.04:5.2.5
     - os: linux
       dist: bionic
       sudo: required
@@ -27,16 +27,14 @@ matrix:
       services: docker
       env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci-ubuntu18.04:latest USE_SWIFT_DEVELOPMENT_SNAPSHOT=1
     - os: osx
-      osx_image: xcode11
+      osx_image: xcode12.2
       sudo: required
       env: SWIFT_SNAPSHOT=5.1.5 JAZZY_ELIGIBLE=true
     - os: osx
-      osx_image: xcode12.2
-      sudo: required
-    - os: osx
-      osx_image: xcode12.5
+      osx_image: xcode13.2
       sudo: required
       env: USE_SWIFT_DEVELOPMENT_SNAPSHOT=1
+
 
 before_install:
   - git clone https://github.com/Kitura/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci-ubuntu16.04:5.2.5
+      env: DOCKER_IMAGE=docker.kitura.net/kitura/swift-ci-ubuntu18.04:5.2.5
     - os: linux
       dist: bionic
       sudo: required
@@ -29,7 +29,7 @@ matrix:
     - os: osx
       osx_image: xcode12.2
       sudo: required
-      env: SWIFT_SNAPSHOT=5.1.5 JAZZY_ELIGIBLE=true
+      env: JAZZY_ELIGIBLE=true
     - os: osx
       osx_image: xcode13.2
       sudo: required

--- a/HTMLEntities.podspec
+++ b/HTMLEntities.podspec
@@ -75,6 +75,7 @@ In addition, `HTMLEntities` can unescape encoded HTML text that contains decimal
   s.osx.deployment_target = "10.10"
   # s.watchos.deployment_target = "2.0"
   # s.tvos.deployment_target = "9.0"
+  s.swift_version = "5.2"
 
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /**


### PR DESCRIPTION
Minimum swift version is now 5.2

Updated podspec, Package.swift, and .travis files.